### PR TITLE
Missing ";" related to using NETWORK_FREQ_60HZ

### DIFF
--- a/src/dimmable_light_linearized.h
+++ b/src/dimmable_light_linearized.h
@@ -59,7 +59,7 @@ class DimmableLightLinearized{
                -1.9126e-05*pow(bri,3)
                +0.0021225*pow(bri,2)
                -0.12471*bri
-               +8.3201    
+               +8.3201;    
 #endif
       tempBrightness *= 1000;
 


### PR DESCRIPTION
Minor typo causing compilation error for me when using NETWORK_FREQ_60HZ - missing ";" for line 62.  I haven't used GitHub before to propose changes, so sorry if I'm doing this wrong.